### PR TITLE
Change unvisited link text to cyan.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,7 +76,10 @@
                     background-color: #161616;
                 }
                 p {
-                    color: 	#e2e2e2;
+                    color: #e2e2e2;
+                }
+                a {
+                    color: #00B7EB;
                 }
                 a:visited {
                     color: #ff7b72;


### PR DESCRIPTION
The dark blue link text on anchor tags gets a bit lost in dark mode. This will change it to a slightly lighter cyan.